### PR TITLE
Update .editorconfig to match project settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,15 @@
-# editorconfig.org
 root = true
 
 [*]
-indent_style = space
-indent_size = 4
-end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
+end_of_line = lf
+indent_size = 4
+indent_style = space
 insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{json,yml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ postcss([devtools(), autoprefixer()]).process(css).then(function (result) {
 
 ##### precise
 
-Type: `boolean`
+Type: `boolean`  
 Default: `false`
 
 This adds extra precision to the times that are reported.
 
 ##### silent
 
-Type: `boolean`
+Type: `boolean`  
 Default: `false`
 
 Set this to `true` to use your own logger for the output of this module.


### PR DESCRIPTION
It looks like .editorconfig might be a little too greedy for other contributors, so I’ve updated it to reflect the projects current implied settings.

Also, it seemed like you intended to have Type and Default on separate lines only without a paragraph break. You need trailing spaces to accomplish this. I have tried to account for this as well, and I’ve separated the commits to hopefully keep things clean.

If you’d like me to change anything, don’t hesitate to ask. Thanks for creating this awesome tool for us.
